### PR TITLE
Fix for @studio.iceAttr path=“{{localId}}” issue

### DIFF
--- a/templates/web/layout/video-list-layout.ftl
+++ b/templates/web/layout/video-list-layout.ftl
@@ -37,7 +37,12 @@
     </script>
 
     <script id="video-table-template" type="text/x-handlebars-template">
-    	<div class = "grid" <@studio.iceAttr  path="{{localId}}" />>
+    	<div class = "grid" 
+            <@studio.iceAttr  
+              path="{{localId}}"
+              embeddedItemId="{{localId}}" 
+            />
+        >
             <h3>{{title_t}}</h3>
             <video id="vid-table-{{folder-name}}" class="video-table" poster="{{thumbnail_s}}" preload="auto">
                 <source src="{{video_s}}" type="video/mp4">

--- a/templates/web/layout/video-list-layout.ftl
+++ b/templates/web/layout/video-list-layout.ftl
@@ -37,32 +37,10 @@
     </script>
 
     <script id="video-table-template" type="text/x-handlebars-template">
-    	<div class = "grid" <@studio.iceAttr  path="{{localId}}" />>
-            <h3>{{title_t}}</h3>
-            <video id="vid-table-{{folder-name}}" class="video-table" poster="{{thumbnail_s}}" preload="auto">
-                <source src="{{video_s}}" type="video/mp4">
-                <p>Your browser does not support H.264/mp4</p>
-            </video>
-            <div class="table-player-container" id="player-table-{{folder-name}}">
-                <span><span>
-            </div>
-            <div class="watch" class="time-video-table">
-                <a href="{{videoUrl}}" class="share-anchor">Watch now</a>
-            </div>
-            <div class="time" class="time-video-table" id="time-table-{{folder-name}}">
-                <span id="span-table-{{folder-name}}">{{duration_s}}</span>
-            </div>
-            <div class="grid-info">
-                <div class="clear"></div>
-                <div class="lables">
-                    <p>Tags:
-                         {{#each tags}}
-    						<a class="generic-tag" onClick="categoryRedirect('{{this.tagName_t}}')" title="Go to 'Watch now' for more information">{{this.tagName_t}}</a>
-  						 {{/each}}
-                    </p>
-                </div>
-            </div>
-         </div>
+        <h3>{{localId}}</h3>
+        <h3>{{title_t}}</h3>
+
+
     </script>
     
     <script id="no-results-table-template" type="text/x-handlebars-template">

--- a/templates/web/layout/video-list-layout.ftl
+++ b/templates/web/layout/video-list-layout.ftl
@@ -37,10 +37,32 @@
     </script>
 
     <script id="video-table-template" type="text/x-handlebars-template">
-        <h3>{{localId}}</h3>
-        <h3>{{title_t}}</h3>
-
-
+    	<div class = "grid" <@studio.iceAttr  path=localId />>
+            <h3>{{title_t}}</h3>
+            <video id="vid-table-{{folder-name}}" class="video-table" poster="{{thumbnail_s}}" preload="auto">
+                <source src="{{video_s}}" type="video/mp4">
+                <p>Your browser does not support H.264/mp4</p>
+            </video>
+            <div class="table-player-container" id="player-table-{{folder-name}}">
+                <span><span>
+            </div>
+            <div class="watch" class="time-video-table">
+                <a href="{{videoUrl}}" class="share-anchor">Watch now</a>
+            </div>
+            <div class="time" class="time-video-table" id="time-table-{{folder-name}}">
+                <span id="span-table-{{folder-name}}">{{duration_s}}</span>
+            </div>
+            <div class="grid-info">
+                <div class="clear"></div>
+                <div class="lables">
+                    <p>Tags:
+                         {{#each tags}}
+    						<a class="generic-tag" onClick="categoryRedirect('{{this.tagName_t}}')" title="Go to 'Watch now' for more information">{{this.tagName_t}}</a>
+  						 {{/each}}
+                    </p>
+                </div>
+            </div>
+         </div>
     </script>
     
     <script id="no-results-table-template" type="text/x-handlebars-template">

--- a/templates/web/layout/video-list-layout.ftl
+++ b/templates/web/layout/video-list-layout.ftl
@@ -37,12 +37,7 @@
     </script>
 
     <script id="video-table-template" type="text/x-handlebars-template">
-    	<div class = "grid" 
-            <@studio.iceAttr  
-              path="{{localId}}"
-              embeddedItemId="{{localId}}" 
-            />
-        >
+    	<div class = "grid" <@studio.iceAttr  path="{{localId}}" />>
             <h3>{{title_t}}</h3>
             <video id="vid-table-{{folder-name}}" class="video-table" poster="{{thumbnail_s}}" preload="auto">
                 <source src="{{video_s}}" type="video/mp4">


### PR DESCRIPTION
Minor change to fix following issue:
`FTL stack trace (“~” means nesting-related):
	- Failed at: #assign item = siteItemService.getSit... [in template “templates/system/common/cstudio-support.ftl” in macro “iceAttr” at line 56, column 9]
	- Reached through: @studio.iceAttr path=“{{localId}}” [in template “templates/web/layout/video-list-layout.ftl” in macro “videoList” at line 40, column 29]
	- Reached through: @videoList.videoList title=“Recent Vi... [in template “templates/web/pages/home-page.ftl” at line 13, column 9]
	~ Reached through: #nested [in template “templates/web/layout/default-layout.ftl” in macro “default” at line 40, column 13]
	~ Reached through: @layout.default [in template “templates/web/pages/home-page.ftl” at line 8, column 1]`

After the update, the `Recent Videos` grid is being displayed correctly

See Attachment:
<img width="1112" alt="Screen Shot 2020-03-19 at 12 25 51 PM" src="https://user-images.githubusercontent.com/10216814/77106467-bba78780-69e4-11ea-98e8-df8174be807f.png">
